### PR TITLE
Fixes for some code bugs and missing instructions 

### DIFF
--- a/docs/apply-and-nested.md
+++ b/docs/apply-and-nested.md
@@ -191,7 +191,7 @@ SparkleFormation.new(:computes) do
   dynamic!(:ec2_instance, :micro) do
     properties do
       image_id 'ami-25c52345'
-      image_type 't2.micro'
+      instance_type 't2.micro'
       key_name ref!(:ssh_key_name)
       network_interfaces array!(
         ->{
@@ -207,7 +207,7 @@ SparkleFormation.new(:computes) do
   dynamic!(:ec2_instance, :small) do
     properties do
       image_id 'ami-25c52345'
-      image_type 't2.micro'
+      instance_type 't2.micro'
       key_name ref!(:ssh_key_name)
       network_interfaces array!(
         ->{

--- a/docs/apply-and-nested.md
+++ b/docs/apply-and-nested.md
@@ -83,7 +83,7 @@ SparkleFormation.new(:network) do
 
   dynamic!(:ec2_vpc, :network) do
     properties do
-      cidr_block join!(ref!(:cidr_prefix, '.0.0/24'))
+      cidr_block join!(ref!(:cidr_prefix), '.0.0/24')
       enable_dns_support true
       enable_dns_hostnames true
     end
@@ -127,7 +127,7 @@ SparkleFormation.new(:network) do
   dynamic!(:ec2_subnet, :network) do
     properties do
       availability_zone select!(0, azs!)
-      cidr_block join!(ref!(:cidr_prefix, '.0.0/24'))
+      cidr_block join!(ref!(:cidr_prefix), '.0.0/24')
       vpc_id ref!(:network_ec2_vpc)
     end
   end
@@ -143,7 +143,7 @@ SparkleFormation.new(:network) do
     network_vpc_id.value ref!(:network_ec2_vpc)
     network_subnet_id.value ref!(:network_ec2_subnet)
     network_route_table.value ref!(:network_ec2_route_table)
-    network_cidr.value join!(ref!(:cidr_prefix, '.0.0/24'))
+    network_cidr.value join!(ref!(:cidr_prefix), '.0.0/24')
   end
 
 end

--- a/docs/apply-and-nested.md
+++ b/docs/apply-and-nested.md
@@ -284,7 +284,7 @@ the outputs from the `sparkle-guide-network`.
 You can destroy the sparkle-guide-compute and sparkle-guide-network stacks as they will not be used in the next section.
 
 ~~~
-$ sfn destroy sparkle-guide-compute
+$ sfn destroy sparkle-guide-computes
 $ sfn destroy sparkle-guide-network
 ~~~
 

--- a/docs/apply-and-nested.md
+++ b/docs/apply-and-nested.md
@@ -173,6 +173,10 @@ SparkleFormation.new(:computes) do
     ssh_key_name.type 'String'
     network_vpc_id.type 'String'
     network_subnet_id.type 'String'
+    image_id_name do
+        type 'String'
+        default 'ami-63ac5803'
+    end
   end
 
   dynamic!(:ec2_security_group, :compute) do
@@ -190,7 +194,7 @@ SparkleFormation.new(:computes) do
 
   dynamic!(:ec2_instance, :micro) do
     properties do
-      image_id 'ami-25c52345'
+      image_id ref!(:image_id_name)
       instance_type 't2.micro'
       key_name ref!(:ssh_key_name)
       network_interfaces array!(
@@ -206,7 +210,7 @@ SparkleFormation.new(:computes) do
 
   dynamic!(:ec2_instance, :small) do
     properties do
-      image_id 'ami-25c52345'
+      image_id ref!(:image_id_name)
       instance_type 't2.micro'
       key_name ref!(:ssh_key_name)
       network_interfaces array!(

--- a/docs/apply-and-nested.md
+++ b/docs/apply-and-nested.md
@@ -277,6 +277,13 @@ During the create process, the SparkleFormation CLI will prompt for parameters. 
 default values for the VPC ID and subnet ID will be automatically inserted, matching
 the outputs from the `sparkle-guide-network`.
 
+You can destroy the sparkle-guide-compute and sparkle-guide-network stacks as they will not be used in the next section.
+
+~~~
+$ sfn destroy sparkle-guide-compute
+$ sfn destroy sparkle-guide-network
+~~~
+
 ## Nested stack implementation
 
 Now that our infrastructure has been successfully created using disparate stacks, lets
@@ -373,3 +380,9 @@ $ bundle exec sfn create sparkle-guide-computes-infra --file computes --apply-st
 
 The ability to apply nested stacks to disparate stacks make it easy to provide resources to new
 stacks, or to test building new stacks in isolation before being nested into the root stack.
+
+You can destroy the all the `infrastructure` related stacks with the command:
+
+~~~
+sfn destroy sparkle-guide-infrastructure
+~~~

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -160,7 +160,7 @@ SparkleFormation.new(:compute, :provider => :heat) do
     sparkle_ssh_key_name.type 'String'
     sparkle_flavor do
       type 'String'
-      default 'm1.small'
+      default 't2.small'
       allowed_values ['m1.small', 'm1.medium']
     end
   end
@@ -334,7 +334,7 @@ Create a new file at `./sparkleformation/registry/instance_flavor.rb`
 
 ~~~ruby
 SfnRegistry.register(:instance_flavor) do
-  ['m1.small', 'm1.medium']
+  ['t2.micro', 't2.small']
 end
 ~~~
 
@@ -411,7 +411,7 @@ SparkleFormation.dynamic(:node) do |name, opts={}|
     set!("#{name}_ssh_key_name".to_sym).type 'String'
     set!("#{name}_flavor".to_sym) do
       type 'String'
-      default 'm1.small'
+      default 't2.small'
       allowed_values registry!(:instance_flavor)
     end
   end
@@ -442,7 +442,7 @@ SparkleFormation.dynamic(:node) do |name, opts={}|
     set!("#{name}_ssh_key_name".to_sym).type 'String'
     set!("#{name}_flavor".to_sym) do
       type 'String'
-      default 'm1.small'
+      default 't2.small'
       allowed_values registry!(:instance_flavor)
     end
   end
@@ -623,14 +623,21 @@ The `--defaults` flag will suppress prompts for stack parameters and use the exi
 stack. The result of this command will either explicitly state that no updates were performed, or the event stream
 will show that no resources were modified depending on the provider.
 
+At the end of the run it will ask:
+
+~~~
+[Sfn]: Apply this stack update? (Y/N):
+~~~
+
+You can answer Y.
+
 ### The real update (parameters)
 
 Now lets update the stack by modifying the paramters of the running stack. We will change the flavor of the instance
-which will result in the resource being replaced within the stack. Run the update command but do not provide any
-flags:
+which will result in the resource being replaced within the stack. Run the update command but do not provide the `--defaults` flag:
 
 ~~~
-$ sfn update sparkle-guide-compute
+$ sfn update sparkle-guide-compute --file compute
 ~~~
 
 Now `sfn` will prompt for parameter values. Notice that the default values are the values used when creating the


### PR DESCRIPTION
Fixed the issues that I had posted in the Issues section plus a few more
- Replaced m1.small/m1.medium with t2.micro and t2.small as you can't migrate from a t2 to an m1 since t2 are HVM images
- Documented how to deal with the end of the section on update
- Specified that --file is needed with _The real update_ section
- Fixed parentheise misplacement for joins of cider_prefix and suffix
- Added instructions for destroying the stacks in the later examples
- Made image_id a ref
